### PR TITLE
Issue #36 Fixes installation for Unix

### DIFF
--- a/content/documentation/download.md
+++ b/content/documentation/download.md
@@ -52,8 +52,8 @@ The following requirements apply to the installation from source:
 In order to build and install IPFS Cluster in Unix systems follow the steps:
 
 ```
-git clone https://github.com/ipfs/ipfs-cluster.git $GOPATH/github.com/ipfs/ipfs-cluster
-cd $GOPATH/github.com/ipfs/ipfs-cluster
+git clone https://github.com/ipfs/ipfs-cluster.git $GOPATH/src/github.com/ipfs/ipfs-cluster
+cd $GOPATH/src/github.com/ipfs/ipfs-cluster
 make install
 ```
 


### PR DESCRIPTION
Current unix installation skip `src` repo and directly puts
`github.com/ipfs/ipfs-cluster` repo in $GOPATH. This commit fixes that
by go getting instead of cloning.

Fixes #36 