### PR TITLE
fix: rebuild main.css on .less change in make dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,17 +30,17 @@ else
 endif
 HUGO_URL="https://github.com/gohugoio/hugo/releases/download/v$(HUGO_VERSION)/hugo_$(HUGO_VERSION)_$(PLATFORM)-$(MACH).tar.gz"
 
+build: clean bin/hugo install lint css
+	$(PREPEND)$(HUGO_BINARY) && \
+	echo "" && \
+	echo "Site built out to ./public dir"
+
 bin/hugo:
 	@echo "Installing Hugo to $(HUGO_LOCAL)..."
 	$(PREPEND)mkdir -p tmp_hugo $(APPEND)
 	$(PREPEND)mkdir -p bin $(APPEND)
 	$(PREPEND)curl --location "$(HUGO_URL)" | tar -xzf - -C tmp_hugo && chmod +x tmp_hugo/hugo && mv tmp_hugo/hugo $(HUGO_LOCAL) $(APPEND)
 	$(PREPEND)rm -rf tmp_hugo $(APPEND)
-
-build: clean install lint css
-	$(PREPEND)$(HUGO_BINARY) && \
-	echo "" && \
-	echo "Site built out to ./public dir"
 
 help:
 	@echo 'Makefile for a cluster.ipfs.io, a hugo built static site.                                                 '
@@ -78,7 +78,7 @@ serve: install lint css
 
 dev: install css
 	$(PREPEND)( \
-		$(NPMBIN)/nodemon --watch layouts/css --exec "$(NPMBIN)/lessc --clean-css --autoprefix layouts/less/main.less static/css/main.css" & \
+		$(NPMBIN)/nodemon --watch layouts/less --ext "less" --exec "$(NPMBIN)/lessc --clean-css --autoprefix layouts/less/main.less static/css/main.css" & \
 		$(HUGO_BINARY) server -w \
 	)
 

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,7 @@
 languageCode = "en-us"
 relativeURLs = true
 sourceRelativeLinksEval = true
+ignoreFiles = [ "\\.less$" ]
 
 [params]
   baseurl = "https://cluster.ipfs.io"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "less": "^2.7.2",
     "less-plugin-autoprefix": "^1.5.1",
     "less-plugin-clean-css": "^1.5.1",
-    "nodemon": "^1.11.0"
+    "nodemon": "^1.18.7"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
This PR bring `make dev` back to working order. Changes to the less files cause the css to be rebuild and the styles to hot-reload in your browser ~1s later.

- have nodemon watch for changes in less files rather than css.
- avoid triggering hugo when a less file changes
- fix the `make` command so it installs and builds all the things.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>