### PR TITLE
Fix broken link to downloads page from docs page

### DIFF
--- a/content/documentation/_index.md
+++ b/content/documentation/_index.md
@@ -17,7 +17,7 @@ Welcome to the IPFS Cluster documentation. This is where you will find user docu
 ## User documentation
 
 * [IPFS Cluster Overview](overview)
-* [Download](download)
+* [Download](../download)
 * [Configuration](configuration)
 * [Starting the Cluster](starting)
 * [Deployment](deployment)


### PR DESCRIPTION
Fixes #50 . Turned out to be a missing `../` problem (and perhaps an interesting Hugo special-special)