### PR TITLE
Remove baseurl from config to fix localhost<>live path problem

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,7 +5,7 @@ ignoreFiles = [ "\\.less$" ]
 sectionPagesMenu = "main"
 
 [params]
-  baseurl = "https://cluster.ipfs.io"
+  # baseurl = "https://cluster.ipfs.io"
   name = "IPFS CLUSTER"
   title = "IPFS CLUSTER"
   description = "Pinset orchestration for IPFS"


### PR DESCRIPTION
Fixes #48 .

Interestingly, it seems you don't need to define `baseurl` in Hugo configs, and when you do, it sometimes causes issues in translation between `localhost` and live. I've removed that param from this fix, but I won't know if it works until pushed live. Fortunately (ha) this is already broken on the live site so there is little risk in testing.