### PR TITLE
Add notice about how to disable log colors

### DIFF
--- a/content/documentation/ipfs-cluster-service.md
+++ b/content/documentation/ipfs-cluster-service.md
@@ -47,5 +47,6 @@ The `ipfs-cluster-service state` subcommands offers access to utilities to `expo
 * `--debug` enables debug logging from the `ipfs-cluster`, `go-libp2p-raft` and `go-libp2p-rpc` layers. This will be a very verbose log output, but at the same time it is the most informative.
 * `--loglevel` sets the log level (`[error, warning, info, debug]`) for the `ipfs-cluster` only, allowing to get an overview of the what cluster is doing. The default log-level is `info`.
 
+By default, logs are coloured. To disable log colours set the `IPFS_LOGGING_FMT` environment variable to `nocolor`.
 
 ## Next steps: [`ipfs-cluster-ctl`](/documentation/ipfs-cluster-ctl)


### PR DESCRIPTION
As discussed in https://github.com/ipfs/ipfs-cluster/issues/660.

Only added to the `ipfs-cluster-service` doc page.
In my opinion, it doesn't make sense to mention this in the `ipfs-cluster-ctl` doc page because all `ctl` commands are meant to be used in a terminal and give immediate feedback (not long-running).