### PR TITLE
Fixed broken link to k8s documentation

### DIFF
--- a/content/documentation/deployment.md
+++ b/content/documentation/deployment.md
@@ -23,7 +23,7 @@ This subsection provides different resources to automate the deployment of an IP
 
 * [Ansible roles](https://github.com/hsanjuan/ansible-ipfs-cluster)
 * [Docker containers and Docker compose](/documentation/deployment/docker)
-* [Kubernetes deployment Guide](/documentations/k8s)
+* [Kubernetes deployment Guide](/documentation/k8s)
 
 
 ### Help completing this section


### PR DESCRIPTION
Found that the k8s deployment link pointed incorrectly,