### PR TITLE
fix: respect users doNotTrack setting

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,12 @@ relativeURLs = true
 sourceRelativeLinksEval = true
 ignoreFiles = [ "\\.less$" ]
 sectionPagesMenu = "main"
+googleAnalytics = "UA-96910779-7"
+
+[privacy]
+  [privacy.googleAnalytics]
+    anonymizeIP = true
+    respectDoNotTrack = true
 
 [params]
   # baseurl = "https://cluster.ipfs.io"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -34,13 +34,7 @@
     <link href="/css/main.css" rel="stylesheet"/>
     <link href="/fonts/fonts.css" rel="stylesheet"/>
     <script async defer src="/buttons.js"></script>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-96910779-7"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-96910779-7');
-    </script>
+    {{ template "_internal/google_analytics.html" . }}
   </head>
   <body>
     {{ partial "header.html" . }}


### PR DESCRIPTION
Use the internal hugo template as @hsanjuan suggested. (sorry!)

The hugo ga template in versions > v0.41 has support for
doNotTrack and ga IP anonymisation, so use that instead of rolling
our own.

it wraps the GA template in a check for `navigator.doNotTrack` and 
enables [IP address anonymisation](https://support.google.com/analytics/answer/2763052?hl=en)

see: https://github.com/gohugoio/hugo/blob/release-0.49/tpl/tplimpl/embedded/templates/google_analytics.html

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>