### PR TITLE
feat: include ipfs-camp ribbon

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -34,6 +34,8 @@
     <link href="/css/main.css" rel="stylesheet"/>
     <link href="/fonts/fonts.css" rel="stylesheet"/>
     <script async defer src="/buttons.js"></script>
+    <!-- ipfs camp -->
+    <script src="https://camp.ipfs.io/ribbon.min.js" async></script>
     {{ template "_internal/google_analytics.html" . }}
   </head>
   <body>


### PR DESCRIPTION
This implements the IPFS Camp ribbon banner 💅

Currently only visible on larger screen layouts but considering the cluster website isn't responsive at the moment this should be sufficient on the lead-up to the event.

![ribbon-ipfs](https://user-images.githubusercontent.com/106938/56133912-63bb0200-5f85-11e9-877f-826342dcc565.jpg)

ref: protocol/2019-ipfs-camp#13