### PR TITLE
fix: escape pipe in api enpoint table

### DIFF
--- a/content/documentation/developer/api.md
+++ b/content/documentation/developer/api.md
@@ -25,9 +25,9 @@ This table provides a quick summary of methods available:
 |`POST`      |`/pins/sync`          |Sync local status from IPFS|
 |`GET`       |`/pins/{cid}`         |Local status of single CID|
 |`POST`      |`/pins/{cid}`         |Pin a CID|
-|`POST`      |`/pins/{ipfs|ipns|ipld}/<path>`|Pin using an IPFS path|
+|`POST`      |`/pins/{ipfs\|ipns\|ipld}/<path>`|Pin using an IPFS path|
 |`DELETE`    |`/pins/{cid}`         |Unpin a CID|
-|`DELETE`    |`/pins/{ipfs|ipns|ipld}/<path>`|Unpin using an IPFS path|
+|`DELETE`    |`/pins/{ipfs\|ipns\|ipld}/<path>`|Unpin using an IPFS path|
 |`POST`      |`/pins/{cid}/sync`    |Sync a CID|
 |`POST`      |`/pins/{cid}/recover` |Recover a CID|
 |`POST`      |`/pins/recover`       |Recover all pins in the receiving Cluster peer|


### PR DESCRIPTION
turns out you have to escape pipes, used inside gfm markdown, even if they occur inside code blocks.
https://github.github.com/gfm/#example-200

who knew. seems like an unplesantness that could have been avoided.

The current HTML conversion matches the github interpretation...

<img width="367" alt="Screenshot 2019-04-16 at 10 23 09" src="https://user-images.githubusercontent.com/58871/56198327-a2f35c80-6032-11e9-99bf-ce665eade51a.png">

This PR should fix it.

<img width="765" alt="Screenshot 2019-04-16 at 10 29 14" src="https://user-images.githubusercontent.com/58871/56198345-adadf180-6032-11e9-8091-d0ce4bfc0c21.png">
