### PR TITLE
updating quickstart to make commands more obvious

### DIFF
--- a/content/documentation/quickstart.md
+++ b/content/documentation/quickstart.md
@@ -66,9 +66,11 @@ Initialize and run cluster in a different node(s), bootstrapping them to the fir
 
 ```
 node1> export CLUSTER_SECRET=<copy from node0>
+
 node1> ipfs-cluster-service init
 INFO     config: Saving configuration config.go:311
 ipfs-cluster-service configuration written to /home/hector/.ipfs-cluster/service.json
+
 node1> ipfs-cluster-service daemon --bootstrap /ip4/192.168.1.2/tcp/9096/ipfs/QmZjSoXUQgJ9tutP1rXjjNYwTrRM9QPhmD9GHVjbtgWxEn
 INFO    cluster: IPFS Cluster v0.3.0 listening on: cluster.go:91
 INFO    cluster:         /ip4/127.0.0.1/tcp/10096/ipfs/QmYFYwnFUkjFhJcSJJGN72wwedZnpQQ4aNpAtPZt8g5fCd cluster.go:93


### PR DESCRIPTION
As I was reading through the Quickstart, I was confused about how the second node was connecting.  It took a while for me to spot where the other command to run it was.

I just put an empty line between each command to make it clearer to those reading what the expected commands and results are.