### PR TITLE
[WIP] Fix broken alias

### DIFF
--- a/content/download/_index.md
+++ b/content/download/_index.md
@@ -1,7 +1,9 @@
 +++
 title = "Download"
 weight = 30
-aliases = ["/documentation/download/"]
+aliases = [
+    "/documentation/download/"
+]
 +++
 
 


### PR DESCRIPTION
For #63 (404 on former download documentation url, should redirect to current download landing page)