### PR TITLE
feat: RSS/Atom feed with full posts

### DIFF
--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -5,4 +5,5 @@ weight = 1
 
 # News
 
-This section contains updates, release notes and blog posts. Visit it regularly to get to know all the news from IPFS Cluster:
+This section contains updates, release notes and blog posts.<br/>
+Subscribe to [RSS/Atom feed](index.xml) or visit it regularly to get to know all the news from IPFS Cluster:

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -14,8 +14,11 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+
     <meta name="msapplication-TileColor" content="#15154f">
     <meta name="theme-color" content="#ffffff">
+
+    <link rel="alternate feed" href="{{ "/news/index.xml" | absURL }}" type="application/rss+xml"  title="IPFS Cluster News" />
 
     <!--  facebook open graph tags -->
     <meta property="og:type" content="website" />

--- a/layouts/news/rss.xml
+++ b/layouts/news/rss.xml
@@ -1,0 +1,32 @@
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>IPFS Cluster News</title>
+    <link>{{ .Permalink }}</link>
+    <image>
+      <url>{{ "/android-chrome-192x192.png" | absURL }}</url>
+      <title>IPFS Cluster News</title>
+      <link>{{ .Permalink }}</link>
+    </image>
+    <description>Recent news on IPFS Cluster</description>
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
+    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{ with .OutputFormats.Get "RSS" }}
+        {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{ end }}
+    {{ range first 10 .Pages  }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Summary | html }}</description>
+      <content:encoded>{{ `<![CDATA[` | safeHTML }}{{ .Content | safeHTML }}{{ `]]>` | safeHTML }}</content:encoded>
+    </item>
+    {{ end }}
+  </channel>
+</rss>


### PR DESCRIPTION
This PR adds improved RSS/Atom template that includes full blogpost in the feed, making it easier to consume in feed readers. We use similar template at https://blog.ipfs.io

It also adds links to the feed for humans and machines.