### PR TITLE
Updates docs link to non-beta site.

### DIFF
--- a/content/documentation/reference/api.md
+++ b/content/documentation/reference/api.md
@@ -21,7 +21,7 @@ As additional resources:
 * All the available API endpoints and their parametres and object formats are supported and documented by the [Go API Client](https://pkg.go.dev/github.com/ipfs/ipfs-cluster/api/rest/client?tab=doc#Client).
 * The [API source code is here](https://github.com/ipfs/ipfs-cluster/blob/master/api/rest/restapi.go) (the `routes` method is a good place to start).
 * A [Javascript client library](https://github.com/ipfs-cluster/js-cluster-client) also exists.
-* The request body for the `/add` endpoint is a bit special, but it works just like the IPFS one. See the [`/api/v0/add` documentation](https://docs-beta.ipfs.io/reference/http/api/#api-v0-add) for information.
+* The request body for the `/add` endpoint is a bit special, but it works just like the IPFS one. See the [`/api/v0/add` documentation](https://docs.ipfs.io/reference/http/api/#api-v0-add) for information.
 
 The above should be enough to find out about the existing endpoints, their methods and current supported options.
 


### PR DESCRIPTION
The legacy IPFS Docs site has been deprecated, so links to `docs-beta.ipfs.io` will auto-redirect to `docs.ipfs.io`. This PR doesn't change much from the user's perspective, but it makes things a bit tidier.