### PR TITLE
config: reduce default pin timeout to 2 minutes

### DIFF
--- a/content/documentation/reference/configuration.md
+++ b/content/documentation/reference/configuration.md
@@ -254,7 +254,7 @@ This is the default and only IPFS Connector implementation. It provides a gatewa
 |`connect_swarms_delay` | `"30s"` | On start, the Cluster Peer will run `ipfs swarm connect` to the IPFS daemons of others peers. This sets the delay after starting up. |
 |`ipfs_request_timeout` | `"5m0s"` | Specifies a timeout on general requests to the IPFS daemon for requets without a specific timeout option. |
 |`repogc_timeout` | `"24h"` | Specifies a timeout on `/repo/gc` operations. |
-|`pin_timeout` | `"24h0m0s"` | Specifies the timeout for `pin/add` which starts from the last block received for the item being pinned. Thus items which are being pinned slowly will not be cancelled even if they take more than 24h. |
+|`pin_timeout` | `"2m0s"` | Specifies the timeout for `pin/add` which starts from the last block received for the item being pinned. Thus items which are being pinned slowly will not be cancelled even if they take more than 24h. |
 |`unpin_timeout` | `"3h0m0s"` | Specifies the timeout for `pin/rm` requests to the IPFS daemon. |
 |`unpin_disable` | `false` | Prevents the connector from unpinning anything (even if the Cluster does). |
 


### PR DESCRIPTION
related to the sourcecode-change in https://github.com/ipfs/ipfs-cluster/pull/1160