### PR TITLE
Add docs for `pin_only_on_untrusted_peers` setting

### DIFF
--- a/content/documentation/reference/configuration.md
+++ b/content/documentation/reference/configuration.md
@@ -137,11 +137,11 @@ The `leave_on_shutdown` option allows a peer to remove itself from the *peerset*
 |`peer_watch_interval`| `"5s"` | Interval for checking the current cluster peerset and detect if this peer was removed from the cluster (and shut-down). |
 |`mdns_interval` | `"10s"` | Setting it to `"0"` disables mDNS. Setting to a larger value enables mDNS but no longer controls anything. |
 |`enable_relay_hop` | `true` | Let the cluster peer acts as relay for other peers that are not reachable directly. |
-|`pin_only_on_trusted_peers` | `false` | The cluster peer will only allocate pins to trusted peers (as configured) |
+|`pin_only_on_trusted_peers` | `false` | The cluster peer will only allocate pins to trusted peers (as configured). Cannot be enabled with `pin_only_on_untrusted_peers`. |
+|`pin_only_on_untrusted_peers` | `false` | The cluster peer will only allocate pins to untrusted peers (as configured). Cannot be enabled with `pin_only_on_trusted_peers`.|
 |`disable_repinning` | `true` | Do not automatically re-pin all items allocated to a peer that becomes unhealthy (down). |
 |`follower_mode` | `false` | Peers in follower mode provide useful error messages when trying to perform actions like pinning. |
 |`peer_addresses` | `[]` | Full peer multiadresses for peers to connect to on boot (similar to manually added entries to the `peerstore` file. |
-|`pin_only_on_trusted_peers` | `false` | Limits the possible allocations given to a pin to those in the `trusted_peers` list |
 
 
 


### PR DESCRIPTION
This PR adds docs for the new `pin_only_on_untrusted_peers` config setting introduced in https://github.com/ipfs-cluster/ipfs-cluster/pull/1977.