### PR TITLE
Fix typos and broken link

### DIFF
--- a/content/documentation/guides/datastore.md
+++ b/content/documentation/guides/datastore.md
@@ -22,7 +22,7 @@ Configuration settings for each of the backends can be found in the
 ## Pebble
 
 [Pebble](https://github.com/cockroachdb/pebble) is a high performant
-backend from Cochroachdb, used by default in Cluster:
+backend from CockroachDB, used by default in Cluster:
 
 * Proven to work well on very large pinsets.
 * Best disk-usage compared to the rest. No need to trigger GC cycles for space reclaim.

--- a/content/documentation/guides/metrics.md
+++ b/content/documentation/guides/metrics.md
@@ -13,7 +13,7 @@ Cluster peers regularly broadcast (using gossipsub) metrics between each others.
 * In crdt-mode they serve to identify the current cluster peerset (list of peers with non expired metrics).
 * They are used to communicate information such as peer names and free-space, which can be used, for example, to make pin allocation decisions.
 
-The metrics are produced by ["informer" components](../../configuration/#the-informer-section). There are currently several types of metrics:
+The metrics are produced by ["informer" components](../../reference/configuration/#the-informer-section). There are currently several types of metrics:
 
 * `ping`: the lack of pings from a given cluster peer signifies that the peer is down and is used to trigger re-pinnings when enabled. The ping metric includes information about each peer, like its peer name, IPFS daemon ID and addresses etc. which are then re-used to fill-in fields in the pin status objects when requested.
 * `freespace`: this metric informs how much free space IPFS has in its repository and is used to decide whether to allocate new pins to this peer or others.

--- a/content/documentation/reference/configuration.md
+++ b/content/documentation/reference/configuration.md
@@ -132,7 +132,7 @@ The `leave_on_shutdown` option allows a peer to remove itself from the *peerset*
 | `}` |||
 | `resource_manager {` | | A libp2p resource manager configuration object. The limits are scaled based on the given options and connections/streams are dropped when reached. Such events are logged. |
 | &nbsp;&nbsp;&nbsp;&nbsp;`enabled` | `true` | Controls whether resource limitations are enabled or fully disabled. |
-| &nbsp;&nbsp;&nbsp;&nbsp;`memory_limit_bytes` | `0` | Controls the maximum amount of RAM memory that the libp2p host should use. When set to `0`, the amount will be set to a 25% of the machine's memory or a minimum of 1GiB. Note that this affects only the libp2p resources and not the overall memory of the cluster node |
+| &nbsp;&nbsp;&nbsp;&nbsp;`memory_limit_bytes` | `0` | Controls the maximum amount of RAM memory that the libp2p host should use. When set to `0`, the amount will be set to a 25% of the machine's memory or a minimum of 1GiB. Note that this affects only the libp2p resources and not the overall memory of the cluster node. |
 | &nbsp;&nbsp;&nbsp;&nbsp;`file_descriptors_limit` | `0` | Controls the maximum number of file-descriptors to use. When set to `0`, the limit will be set to 50% of the total amount of file descriptors available to the process. |
 | `}` |||
 | `pubsub {` | | A libp2p pubsub configuration object. This allows to configure pubsub internals. Defaults are optimized for ipfs-cluster pubsub usecase, where metrics and CRDT-heads are broadcasted, and it is not generally fatal if a message gets lost. Deviations from pubsub defaults aim to reduce unnecessary chatter in standard clusters as pubsub ends up using a lot of bandwidth. |


### PR DESCRIPTION
I fixed the typos and broken link in the documentation.